### PR TITLE
Adding support for parallel jobs

### DIFF
--- a/publish_jenkins_console.py
+++ b/publish_jenkins_console.py
@@ -3,7 +3,7 @@ import argparse
 import json
 import os
 import re
-from collections import OrderedDict
+from collections import defaultdict
 
 import requests
 from jenkinsapi.jenkins import Jenkins
@@ -45,7 +45,7 @@ print 'Job Filter pattern: "{}"'.format(_ARGS.filter)
 print 'Jenkins Version: {}'.format(JENKINS.version)
 
 # create dict to hold nested builds and it is status
-ALL_BUILDS = OrderedDict()
+ALL_BUILDS = defaultdict(set)
 BUILD_STATUS = {}
 LOGS_URL = {}
 # list of supported emojis in GitHub
@@ -53,7 +53,7 @@ LOGS_URL = {}
 ICONS = {
     'SUCCESS': ':heavy_check_mark:',
     'FAILURE': ':red_circle:',
-    'UNATABLE': ':question:',
+    'UNSTABLE': ':question:',
     'ABORTED': ':black_circle:'
     }
 
@@ -63,10 +63,23 @@ def _update_builds(console_log):
         _name, _id = _job.split(' #')
         _id = int(_id)
         if _name in JENKINS.keys():
-            ALL_BUILDS[_name] = _id
+            ALL_BUILDS[_name].add(_id)
             _build = _get_build(_name, _id)
-            BUILD_STATUS[_name] = _get_status(_build)
             _update_builds(_build.get_console())
+
+
+def _update_build_statuses():
+    for _name, _ids in ALL_BUILDS.items():
+        BUILD_STATUS[_name] = 'SUCCESS'
+        for _id in _ids:
+            _build = _get_build(_name, _id)
+            _status = _get_status(_build)
+            if _status == 'FAILURE':
+                BUILD_STATUS[_name] = _status
+            if _status == 'UNSTABLE' and BUILD_STATUS[_name] != 'FAILURE':
+                BUILD_STATUS[_name] = _status
+            if _status == 'ABORTED' and BUILD_STATUS[_name] != 'FAILURE':
+                BUILD_STATUS[_name] = _status
 
 
 def _get_status(_build):
@@ -83,9 +96,11 @@ def _get_build(_name, _number):
     return JENKINS[_name].get_build(buildnumber=_number)
 
 
-def _upload_console_log(_name, _number):
-    _content = _get_build(_name, _number).get_console().replace('\n', '\n')
-    _data = {'title': '{}: #{}'.format(_name, _number), 'contents': _content}
+def _upload_console_log(_name, _ids):
+    _content = ""
+    for _id in _ids:
+        _content += _get_build(_name, _id).get_console().replace('\n', '\n')
+    _data = {'title': '{}: #{}'.format(_name, _ids), 'contents': _content}
     _response = requests.post(
         FPASTE_URL, headers={'Content-Type': 'application/json'}, data=json.dumps(_data))
     _url = None
@@ -93,34 +108,36 @@ def _upload_console_log(_name, _number):
         _url = _response.json()['url']
     else:
         print('Failed to push the data for the job[name:{}, build_number:{}]'.format(
-            _name, _number))
+            _name, _ids))
     return _url
 
 
 # update primary build to dict
-ALL_BUILDS[_ARGS.job_name] = _ARGS.build_number
+ALL_BUILDS[_ARGS.job_name].add(_ARGS.build_number)
 # update primary build status
 BUILD_STATUS[_ARGS.job_name] = _get_status(BUILD)
 # update nested build details
 _update_builds(BUILD.get_console())
+# update status of all builds
+_update_build_statuses()
 # print details on console
 print ALL_BUILDS
 print BUILD_STATUS
 
 # upload console logs to fpaste
-for _name, _number in ALL_BUILDS.items():
-    _url = _upload_console_log(_name, _number)
+for _name, _ids in ALL_BUILDS.items():
+    _url = _upload_console_log(_name, _ids)
     if _url:
-        print '{} #{} => {}'.format(_name, _number, _url)
+        print '{} #{} => {}'.format(_name, _ids, _url)
         LOGS_URL[_name] = _url
 # formate comment log to upload on GitHub
 _FINAL_LOG = '{} Jenkins CI: {} [#{}]({})'.format(
     ICONS[BUILD_STATUS[_ARGS.job_name]], _ARGS.job_name, _ARGS.build_number,
     LOGS_URL[_ARGS.job_name])
-for _j_name, _j_number in ALL_BUILDS.items():
+for _j_name, _j_ids in ALL_BUILDS.items():
     if _j_name != _ARGS.job_name:
         _FINAL_LOG = _FINAL_LOG + '\n  * {} {} [#{}]({})'.format(
-            ICONS[BUILD_STATUS[_j_name]], _j_name, _j_number, LOGS_URL[_j_name])
+            ICONS[BUILD_STATUS[_j_name]], _j_name, _j_ids, LOGS_URL[_j_name])
 # write formatted log into a file
 with open(COMMENT_MD_FILE, mode="w") as _FILE:
     _FILE.write(_FINAL_LOG)


### PR DESCRIPTION
When we run more instances of the same job concurrently we want to
capture logs from all jobs.